### PR TITLE
Drop NodeGit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ How
 ### From command line
 
 ```sh
-npm-git-install
+npm-git-install install
 ```
 
-This simple script will `git clone` anything it finds in `gitDependencies` section of `package.json` into temporary directory, run `npm install` in this directory (which will trigger `prepublish`) and then `npm install <temporary directory>` in your project. In effect you will get your dependency properly installed.
+This simple script will `git clone` anything it finds in `gitDependencies` section of `package.json` into temporary directory using the optional `git-shrinkwrap.json` file, run `npm install` in this directory (which will trigger `prepublish`) and then `npm install <temporary directory>` in your project. In effect you will get your dependency properly installed.
 
-You can optionally specify file different then `package.json`, e.g.:
+You can optionally specify file different then `package.json` and `git-shrinkwrap.json`, e.g.:
 
 ```sh
-npm-git-install git-dependencies.json
+npm-git-install -c git-dependencies.json -w git-depencencies-shrinkwrap.json
 ```
 
 You may want to do this if you find it offensive to put non-standard section in your `package.json`.
@@ -63,19 +63,19 @@ Also try `--help` for more options.
 
 ### API
 
-You can also use it programmatically. Just require `npm-git-install`. It exposes three methods:
+You can also use it programmatically. Just require `npm-git-install`. It exposes four methods:
 
   * `discover (path)`
 
     Reads list of packages from file at given path and returns array of `{url, revision}` objects. You can supply this to `reinstall_all` method.
 
-  * `reinstall_all (options, packages)`
+  * `reinstall_all (packages, options)`
 
     Executes `reinstall` in series for each package in `packages`. Options are also passed to each `reinstall` call.
 
     Returns a `Promise`.
 
-  * `reinstall (oprions, package)`
+  * `reinstall (package, oprions)`
 
     Clones the repo at `package.url`, checks out `package.revisios`, runs `npm install` at cloned repos directory and installs the package from there.
 
@@ -87,6 +87,14 @@ You can also use it programmatically. Just require `npm-git-install`. It exposes
     Returns a `Promise`.
 
     You probably don't want to use it directly. Just call `reinstall_all` with relevant options.
+
+  * `shrinkwrap (packages, options)`
+
+    The shrinkwrap file will lock each git dependency to the sha specified in the file.
+    
+    `shrinkwrap` creates a shrinkwrap file (default: `git-shrinkwrap.json`) in series containing a sha for each package in `packages`, which will be the latest sha in the specified branch from `packages`.  
+
+    Returns nothing.
 
 If you are a [Gulp][] user, then it should be easy enough to integrate it with your gulpfile.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ In your `pacakge.json` add:
 
 Obviously replace `*-package-name` and git URLs with values relevant to your project. URLs has to be in canonical form (i.e. one that you would provide to `git clone` on command line) - no fancy NPM shortcuts like "user/repo" or "bitbucket:user/repo". If you want this, I'm open for PR.
 
+Then install your dependencies as usual:
+
+```sh
+npm install
+```
+
 Why
 ---
 
@@ -63,12 +69,10 @@ This simple script will do the following for every `<url>` of `gitDependencies` 
 
 In effect you will get your dependency properly installed.
 
-Otionally it will use `git-shrinkwrap.json` file to lock your dependencies to a certain revision (i.e. a commit).
-
-You can optionally specify different paths for `package.json` and `git-shrinkwrap.json`, e.g.:
+You can optionally specify different paths for `package.json`:
 
 ```sh
-npm-git install -c git-dependencies.json -w git-depencencies-shrinkwrap.json
+npm-git install -c git-dependencies.json
 ```
 
 You may want to do this if you find it offensive to put non-standard section in your `package.json`.
@@ -113,16 +117,6 @@ You can also use it programmatically. Just require `npm-git-install`. It exposes
     Returns a `Promise`.
 
     You probably don't want to use it directly. Just call `reinstall_all` with relevant options.
-
-  * `shrinkwrap (options, packages)`
-
-    The shrinkwrap file will lock each git dependency to the sha specified in the file.
-
-    `shrinkwrap` creates a shrinkwrap file (default: `git-shrinkwrap.json`) in series containing a sha for each package in `packages`, which will be the latest sha in the specified branch from `packages`.
-
-    Options are the same as for `reinstall`.
-
-    Returns nothing.
 
 If you are a [Gulp][] user, then it should be easy enough to integrate it with your gulpfile.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In your `pacakge.json` add:
 ```javascript
 {
   "scripts": {
-    "install": "npm-git-install"
+    "install": "npm-git install"
   }
   "gitDependencies": {
     "private-package-name": "git@private.git.server:user/repo.git#revision",
@@ -27,16 +27,16 @@ In your `pacakge.json` add:
 }
 ```
 
-Obviously replace `*-package-name` and git URLs with values relevant to your project. URLs has to be in cannonical form (i.e. one that you would provide to `git clone` on command line) - no fancy NPM shortcuts like "user/repo" or "bitbucket:user/repo". If you want this, I'm open for PR. Actually I started to implement this, but gave up - see `messy-auto-discovery` branch.
+Obviously replace `*-package-name` and git URLs with values relevant to your project. URLs has to be in canonical form (i.e. one that you would provide to `git clone` on command line) - no fancy NPM shortcuts like "user/repo" or "bitbucket:user/repo". If you want this, I'm open for PR.
 
 Why
 ---
 
-IMO there is a serious defect in current versions of NPM regarding installation process of dependencies from git repositories. It basically prevents us from installing anything that needs build from git repos, or forcing us to keep build artifacts in the repos. Here is [relevant issue with ongoing discussion][3055].
+IMO there is a serious defect in current versions of NPM regarding installation process of dependencies from git repositories. It basically prevents us from installing anything that needs a build step directly from git repos. Because of that some authors are keeping build artifacts in the repos, which I would consider a hurdle at best. Here is [relevant issue with ongoing discussion][3055].
 
 ### TL/DR:
 
-If you `npm install ../some-local-directory/my-package` then npm will run `prepublish` script of the `package-from-local-directory` and then install it in current project. This is fine.
+If you `npm install ../some-local-directory/my-package` then npm will run `prepublish` script of the `my-package` and then install it in current project. This is fine.
 
 One would expect that running `npm install git@remote-git-server:me/my-package.git` would also run `prepublish` before installing. Unfortunately it won't. Further more, it will apply `.npmignore`, which will most likely remove all your source files and make it hard to recover. Boo...
 
@@ -46,15 +46,29 @@ How
 ### From command line
 
 ```sh
-npm-git-install install
+npm-git install
 ```
 
-This simple script will `git clone` anything it finds in `gitDependencies` section of `package.json` into temporary directory using the optional `git-shrinkwrap.json` file, run `npm install` in this directory (which will trigger `prepublish`) and then `npm install <temporary directory>` in your project. In effect you will get your dependency properly installed.
+This simple script will do the following for every `<url>` of `gitDependencies` section of `package.json`:
 
-You can optionally specify file different then `package.json` and `git-shrinkwrap.json`, e.g.:
+1.  Clone the repo it into temporary directory
+
+    using `git clone <url>`.
+
+1.  Run `npm install` in this directory
+
+    which will trigger `prepublish` hook of the package being installed.
+
+1.  then run `npm install <temporary directory>` in your project path.
+
+In effect you will get your dependency properly installed.
+
+Otionally it will use `git-shrinkwrap.json` file to lock your dependencies to a certain revision (i.e. a commit).
+
+You can optionally specify different paths for `package.json` and `git-shrinkwrap.json`, e.g.:
 
 ```sh
-npm-git-install -c git-dependencies.json -w git-depencencies-shrinkwrap.json
+npm-git install -c git-dependencies.json -w git-depencencies-shrinkwrap.json
 ```
 
 You may want to do this if you find it offensive to put non-standard section in your `package.json`.
@@ -67,17 +81,29 @@ You can also use it programmatically. Just require `npm-git-install`. It exposes
 
   * `discover (path)`
 
-    Reads list of packages from file at given path and returns array of `{url, revision}` objects. You can supply this to `reinstall_all` method.
+    Reads list of packages from file at given path (e.g. a package.json) and returns array of `{url, revision}` objects. You can supply this to `reinstall_all` method.
 
-  * `reinstall_all (packages, options)`
+  * `reinstall_all (options, packages)`
 
     Executes `reinstall` in series for each package in `packages`. Options are also passed to each `reinstall` call.
 
+    This function is curried, so if you provide just `options` argument you will get a new function that takes only one argument - `packages` array.
+
+    Options are the same as for `reinstall`.
+
     Returns a `Promise`.
 
-  * `reinstall (package, oprions)`
+  * `reinstall (options, package)`
 
-    Clones the repo at `package.url`, checks out `package.revisios`, runs `npm install` at cloned repos directory and installs the package from there.
+    Most of the heavy lifting happens here:
+
+    1.  Clones the repo at `package.url`,
+
+    1.  Checks out `package.revision`
+
+    1.  runs `npm install` at cloned repos directory
+
+    1.  installs the package from there.
 
     Options are:
 
@@ -88,11 +114,13 @@ You can also use it programmatically. Just require `npm-git-install`. It exposes
 
     You probably don't want to use it directly. Just call `reinstall_all` with relevant options.
 
-  * `shrinkwrap (packages, options)`
+  * `shrinkwrap (options, packages)`
 
     The shrinkwrap file will lock each git dependency to the sha specified in the file.
-    
-    `shrinkwrap` creates a shrinkwrap file (default: `git-shrinkwrap.json`) in series containing a sha for each package in `packages`, which will be the latest sha in the specified branch from `packages`.  
+
+    `shrinkwrap` creates a shrinkwrap file (default: `git-shrinkwrap.json`) in series containing a sha for each package in `packages`, which will be the latest sha in the specified branch from `packages`.
+
+    Options are the same as for `reinstall`.
 
     Returns nothing.
 
@@ -100,7 +128,7 @@ If you are a [Gulp][] user, then it should be easy enough to integrate it with y
 
 ### Why not use `dependencies` and `devDependencies`
 
-I tried and it's hard, because NPM supports [fancy things as Git URLs][URLs]. See `messy-auto-discovery` branch. You are welcome to take it from where I left. There is `--all` CLI option reserved that should do that. It is currently not supported.
+I tried and it's hard, because NPM supports [fancy things as Git URLs][URLs]. See `messy-auto-discovery` branch. You are welcome to take it from where I left.
 
 There is also another reason. User may not want to reinstall all Git dependencies this way. For example I use gulp version 4, which is only available from GitHub and it is perfectly fine to install it with standard NPM. I don't want to rebuild it on my machine every time I install it. Now I can leave it in `devDependencies` and only use `npm-git-install` for stuff that needs it.
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.9.0",
+    "jsonfile": "^2.3.1",
     "nodegit": "^0.14.1",
     "temp": "^0.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.9.0",
-    "jsonfile": "^2.3.1",
-    "nodegit": "^0.14.1",
     "temp": "^0.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@celkamada/npm-git-install",
+  "name": "npm-git-install",
   "version": "0.1.7",
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-git-install",
-  "version": "0.1.7",
+  "version": "0.1.4",
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celkamada/npm-git-install",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",
   "bin": {
-    "npm-git-install": "build/cli.js"
+    "npm-git": "build/cli.js"
   },
   "scripts": {
     "prepublish": "coffee --no-header -cbmo build src",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celkamada/npm-git-install",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "npm-git-install",
-  "version": "0.1.3",
+  "name": "@celkamada/npm-git-install",
+  "version": "0.1.4",
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celkamada/npm-git-install",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Clones and (re)installs packages from remote git repos",
   "main": "build/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.9.0",
-    "nodegit": "^0.11.6",
+    "nodegit": "^0.14.1",
     "temp": "^0.8.3"
   },
   "devDependencies": {

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -5,22 +5,28 @@
   discover
   reinstall_all
   shrinkwrap
-}         = require '.'
-cli       = require 'commander'
-path      = require 'path'
-fs        = require 'fs'
+}           = require '.'
+cli         = require 'commander'
+path        = require 'path'
+fs          = require 'fs'
 
+cwd         = process.cwd()
+
+# Command line options
+# See below for sub-commands definitions
 cli
   .version '0.0.0' # TODO: Read from package.json
   .description """
     A utility to properly install npm git dependencies.
   """
   .option '-s --silent',  'suppress child processes output'
-  .option '-w, --git_shrinkwrap <path>', 'Optional git shrinkwrap file location'
-  .option '-c, --package <path>', 'Optional git shrinkwrap file location'
+  .option '-w, --git-shrinkwrap <path>', 'Optional git shrinkwrap file location [git-shrinkwrap.json]' # NOTE: No default value for shrinkwrap here. See apply_shrinkwrap helper.
+  .option '-c, --package <path>', 'Optional package.json file location [package.json]', "package.json"
   .option '-v --verbose', 'be verbose'
-  #.option '-a --all',     'reinstall all git dependencies and devDependencies'
   .option '-d --dry',     'just print what packages would be installed'
+
+# Helper functions
+# Most of the work with promises
 
 conf_file_error = (file) ->
   console.error "package file '#{file}' not found."
@@ -43,51 +49,141 @@ validate_paths = (options) ->
   catch
     conf_file_error options.package
 
-print = (packages, options) ->
+###
+tap : Function -> Identity
+
+Executes a function on a value and returns value, ignoring whatever the function returns. Useful for debugging or performing other side effects.
+###
+tap = (fn) -> (value) ->
+  fn value
+  return value
+
+###
+print_list : String -> Object -> [String] -> undefined
+
+Prints formated list of strings with title. Useful for printing list of discovered packages.
+###
+print_list = (title = "List", options = {}) -> (list) ->
   return unless options.dry or options.verbose
-  console.log 'Detected packages:'
-  console.log ' ' + packages.join '\n'
+  console.log "#{title}:"
+  for item in list
+    console.log "  #{item}"
   console.log ''
 
-dry_guardian = (options) ->
+###
+dry_guardian : Object -> -> undefined
+
+Terminate the script if options.dry is truthy.
+###
+dry_guardian = (options) -> () ->
   return unless options.dry
 
   console.log 'Finished dry run.'
   console.log ''
   process.exit 0
 
-run_install = (options) ->
-  try
-    opts = options.parent
-    validate_paths opts
-    packages = discover opts.package
-    print packages, opts
-    dry_guardian opts
-    reinstall_all packages, opts
-  catch error
-    console.error error
-    process.exit 1
+###
+read_shrinkwrap : Object -> String -> Object
 
-run_shrinkwrap = (options) ->
-  try
-    opts = options.parent
-    validate_paths opts
-    packages = discover opts.package
-    print packages, opts
-    dry_guardian opts
-    shrinkwrap packages, opts
-  catch error
-    console.error error
-    process.exit 1
+Attempts to read shrinkwrapped dependencies from file. If optioms.hard is truthy and file does not exist then terminates the script.
+###
+read_shrinkwrap = (options, file) ->
+  location = path.resolve cwd, file
+  console.log options
 
-cli
-  .command 'shrinkwrap'
-  .description 'bump all git dependencies to latest and generate a git-shrinkwrap.json file'
-  .action run_shrinkwrap
+  try
+    { dependencies } = require location
+    return dependencies
+  catch error
+    switch
+      when options.hard and error.code is "MODULE_NOT_FOUND"
+        ###
+        If git-shrinkwrap option was explicitly provided (signified by options.hard) and file doesn't exists, then terminate abnormally:
+        ###
+        console.error "No such file: #{location}"
+        process.exit 2
+      when error.code is "MODULE_NOT_FOUND"
+        ###
+        If git-shrinkwrap option was not provided (i.e. options.hard is falsy), then lack of git-shrinkwrap.json file is an expected error.
+
+        In this case just return an empty map, as if no pacakge was shrinkwrapped - which is exactly the case.
+        ###
+        if options.verbose
+          console.log "Shrinkwrap file not found. That's ok. Proceeding.",
+
+        return {}
+
+      else
+        ###
+        Rethrow any other (unexpected) error
+        ###
+        throw error
+
+###
+apply_shrinkwrap : Object -> Object -> [Object] -> [Object]
+
+TODO: apply_shrinkwrap should actually go to the API
+###
+apply_shrinkwrap = (options, shrinkwrap) -> (packages) ->
+  file = options["gitShrinkwrap"] ? "git-shrinkwrap.json"
+
+  if options.verbose
+    console.log "Applying shrinkwrap from #{file}"
+
+  options = Object.assign {}, options,
+    hard: options["gitShrinkwrap"]?
+
+  shrinkwrap = read_shrinkwrap options, file
+
+
+
+  console.log {dependencies}
 
 cli
   .command 'install'
   .description 'install git dependencies'
-  .action run_install
+  .action (command) ->
+    options = command.parent.opts()
+    if options.verbose or options.dry
+      console.log "Installing packages from #{options.package}"
+
+    shrinkwrap =
+
+    Promise
+      .resolve discover options.package
+      .then tap print_list "Discovered packages", options
+      # TODO: .then apply_shrinkwrap options # TODO: Implement
+      .then tap dry_guardian options
+      .then reinstall_all options
+      .then (revisions) ->
+      .catch (error) ->
+        console.error
+
+
+
+# run_shrinkwrap = (options) ->
+#   try
+#     opts = options.parent
+#     validate_paths opts
+#     packages = discover opts.package
+#     print packages, opts
+#     dry_guardian opts
+#     shrinkwrap packages, opts
+#   catch error
+#     console.error error
+#     process.exit 1
+#
+cli
+  .command 'shrinkwrap'
+  .description 'bump all git dependencies to latest and generate a git-shrinkwrap.json file'
+  .action (command) ->
+    options = command.parent.opts()
+
+    if options.verbose or options.dry
+      console.log "Preparing shrinkwrap of packages from #{options.package}"
+
+    Promise
+      .resolve discover options.package
+      .then tap print "Discovered packa"
 
 cli.parse process.argv

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -4,7 +4,6 @@
 {
   discover
   reinstall_all
-  shrinkwrap
 }           = require '.'
 cli         = require 'commander'
 path        = require 'path'
@@ -20,34 +19,12 @@ cli
     A utility to properly install npm git dependencies.
   """
   .option '-s --silent',  'suppress child processes output'
-  .option '-w, --git-shrinkwrap <path>', 'Optional git shrinkwrap file location [git-shrinkwrap.json]' # NOTE: No default value for shrinkwrap here. See apply_shrinkwrap helper.
-  .option '-c, --package <path>', 'Optional package.json file location [package.json]', "package.json"
+  .option '-c --package <path>', 'Optional package.json file location [package.json]', "package.json"
   .option '-v --verbose', 'be verbose'
   .option '-d --dry',     'just print what packages would be installed'
 
 # Helper functions
 # Most of the work with promises
-
-conf_file_error = (file) ->
-  console.error "package file '#{file}' not found."
-  process.exit 1
-
-validate_paths = (options) ->
-  options.package ?= 'package.json'
-  options.package = path.resolve options.package
-
-  options.git_shrinkwrap ?= 'git-shrinkwrap.json'
-  options.git_shrinkwrap = path.resolve options.git_shrinkwrap
-
-  try
-    file_stat = fs.statSync(options.package)
-    if !file_stat || !file_stat.isFile()
-      conf_file_error options.package
-
-    if options.verbose
-      console.log "Reading dependencies from #{options.package}"
-  catch
-    conf_file_error options.package
 
 ###
 tap : Function -> Identity
@@ -82,63 +59,6 @@ dry_guardian = (options) -> () ->
   console.log ''
   process.exit 0
 
-###
-read_shrinkwrap : Object -> String -> Object
-
-Attempts to read shrinkwrapped dependencies from file. If optioms.hard is truthy and file does not exist then terminates the script.
-###
-read_shrinkwrap = (options, file) ->
-  location = path.resolve cwd, file
-  console.log options
-
-  try
-    { dependencies } = require location
-    return dependencies
-  catch error
-    switch
-      when options.hard and error.code is "MODULE_NOT_FOUND"
-        ###
-        If git-shrinkwrap option was explicitly provided (signified by options.hard) and file doesn't exists, then terminate abnormally:
-        ###
-        console.error "No such file: #{location}"
-        process.exit 2
-      when error.code is "MODULE_NOT_FOUND"
-        ###
-        If git-shrinkwrap option was not provided (i.e. options.hard is falsy), then lack of git-shrinkwrap.json file is an expected error.
-
-        In this case just return an empty map, as if no pacakge was shrinkwrapped - which is exactly the case.
-        ###
-        if options.verbose
-          console.log "Shrinkwrap file not found. That's ok. Proceeding.",
-
-        return {}
-
-      else
-        ###
-        Rethrow any other (unexpected) error
-        ###
-        throw error
-
-###
-apply_shrinkwrap : Object -> Object -> [Object] -> [Object]
-
-TODO: apply_shrinkwrap should actually go to the API
-###
-apply_shrinkwrap = (options, shrinkwrap) -> (packages) ->
-  file = options["gitShrinkwrap"] ? "git-shrinkwrap.json"
-
-  if options.verbose
-    console.log "Applying shrinkwrap from #{file}"
-
-  options = Object.assign {}, options,
-    hard: options["gitShrinkwrap"]?
-
-  shrinkwrap = read_shrinkwrap options, file
-
-
-
-  console.log {dependencies}
-
 cli
   .command 'install'
   .description 'install git dependencies'
@@ -147,43 +67,12 @@ cli
     if options.verbose or options.dry
       console.log "Installing packages from #{options.package}"
 
-    shrinkwrap =
-
     Promise
       .resolve discover options.package
       .then tap print_list "Discovered packages", options
-      # TODO: .then apply_shrinkwrap options # TODO: Implement
       .then tap dry_guardian options
       .then reinstall_all options
-      .then (revisions) ->
       .catch (error) ->
         console.error
-
-
-
-# run_shrinkwrap = (options) ->
-#   try
-#     opts = options.parent
-#     validate_paths opts
-#     packages = discover opts.package
-#     print packages, opts
-#     dry_guardian opts
-#     shrinkwrap packages, opts
-#   catch error
-#     console.error error
-#     process.exit 1
-#
-cli
-  .command 'shrinkwrap'
-  .description 'bump all git dependencies to latest and generate a git-shrinkwrap.json file'
-  .action (command) ->
-    options = command.parent.opts()
-
-    if options.verbose or options.dry
-      console.log "Preparing shrinkwrap of packages from #{options.package}"
-
-    Promise
-      .resolve discover options.package
-      .then tap print "Discovered packa"
 
 cli.parse process.argv

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -4,55 +4,106 @@
 {
   discover
   reinstall_all
+  shrinkwrap
 }         = require '.'
 cli       = require 'commander'
 path      = require 'path'
+fs        = require 'fs'
 
 cli
   .version '0.0.0' # TODO: Read from package.json
   .description """
     A utility to properly install npm git dependencies.
   """
-  .arguments '<file>'
   .option '-s --silent',  'suppress child processes output'
+  .option '-w, --git_shrinkwrap <path>', 'Optional git shrinkwrap file location'
+  .option '-c, --package <path>', 'Optional git shrinkwrap file location'
   .option '-v --verbose', 'be verbose'
-  .option '-a --all',     'reinstall all git dependencies and devDependencies'
+  #.option '-a --all',     'reinstall all git dependencies and devDependencies'
   .option '-d --dry',     'just print what packages would be installed'
-  .parse process.argv
 
-{
-  silent
-  verbose
-  all
-  dry
-  args: [ file ]
-} = cli
-
-file ?= 'package.json'
-
-if all
-  # TODO: Implement messy, but compatible discovery
-  console.error "I'd love to do it all, but it's not implemented yet. Sorry."
+conf_file_error = (file) ->
+  console.error "package file '#{file}' not found."
   process.exit 1
 
-file = path.resolve file
-if verbose then console.log "Reading dependencies from #{file}"
+validate_paths = (options) ->
+  options.package ?= 'package.json'
+  options.package = path.resolve options.package
 
-tap = (fn) -> (value) ->
-  fn value
-  return value
+  options.git_shrinkwrap ?= 'git-shrinkwrap.json'
+  options.git_shrinkwrap = path.resolve options.git_shrinkwrap
 
-print = (packages) ->
-  if dry or verbose then console.log packages.join '\n'
+  try
+    file_stat = fs.statSync(options.package)
+    if !file_stat || !file_stat.isFile()
+      conf_file_error options.package
 
-dry_guardian = ->
-  if dry then process.exit 0
+    if options.verbose
+      console.log "Reading dependencies from #{options.package}"
+  catch
+    conf_file_error options.package
 
-Promise
-  .resolve discover 'package.json'
-  .then tap print
-  .then tap dry_guardian
-  .then reinstall_all {silent, verbose}
-  .catch (error) ->
-    console.error error
-    throw error
+  try
+    shrinkwrap_stat = fs.statSync(options.git_shrinkwrap)
+    if !shrinkwrap_stat || !shrinkwrap_stat.isFile()
+      options.git_shrinkwrap = ''
+
+    if options.verbose && options.git_shrinkwrap
+      console.log "Using shrinkwrap from #{options.git_shrinkwrap}"
+  catch
+    options.git_shrinkwrap = ''
+
+print = (packages, options) ->
+  return unless options.dry or options.verbose
+  console.log 'Detected packages:'
+  console.log ' ' + packages.join '\n'
+  console.log ''
+
+dry_guardian = (options) ->
+  return unless options.dry
+
+  console.log 'Finished dry run.'
+  console.log ''
+  process.exit 0
+
+cli
+  .command 'shrinkwrap'
+  .description 'bump all git dependencies to latest and generate a git-shrinkwrap.json file'
+  .action((options) ->
+    try
+      opts = options.parent
+      validate_paths opts
+      packages = discover opts.package
+      print packages, opts
+      dry_guardian opts
+      shrinkwrap packages, opts
+    catch error
+      console.error error
+      process.exit 1
+  )
+
+cli
+  .command 'install'
+  .description 'install git dependencies'
+  .action((options) ->
+
+    try
+      opts = options.parent
+      validate_paths opts
+      packages = discover opts.package
+      print packages, opts
+      dry_guardian opts
+      reinstall_all packages, opts
+    catch error
+      console.error error
+      process.exit 1
+  )
+
+cli
+  .command '*'
+  .action((cmd, options) ->
+    console.error 'Invalid command'
+    process.exit 1
+  )
+
+cli.parse process.argv

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -31,52 +31,38 @@ reinstall = (options = {}, pkg) ->
   curried = ({url, revision}) ->
     do temp.track
     tmp = null
+    stdio = [
+      'pipe'
+      if silent then 'pipe' else process.stdout
+      process.stderr
+    ]
+
     mktmp 'npm-git-'
       .then (path) ->
         tmp = path
         cmd = "git clone #{url} #{tmp}"
         if verbose then console.log "Cloning '#{url}' into #{tmp}"
 
-        exec cmd,
-          stdio : [
-            'pipe'
-            if silent then 'pipe' else process.stdout
-            process.stderr
-          ]
+        exec cmd, { stdio }
+
       .then ->
         cmd = "git checkout #{revision}"
 
         if verbose then console.log "Checking out #{revision}"
 
-        exec cmd,
-          cwd   : tmp
-          stdio : [
-            'pipe'
-            if silent then 'pipe' else process.stdout
-            process.stderr
-          ]
+        exec cmd, { cwd: tmp, stdio }
 
       .then ->
         cmd = 'npm install'
         if verbose then console.log "executing #{cmd}"
 
-        exec cmd,
-          cwd   : tmp
-          stdio : [
-            'pipe'
-            if silent then 'pipe' else process.stdout
-            process.stderr
-          ]
+        exec cmd, { cwd: tmp, stdio }
+
       .then ->
         cmd = "npm install #{tmp}"
         if verbose then console.log "executing #{cmd}"
 
-        exec cmd,
-          stdio : [
-            'pipe'
-            if silent then 'pipe' else process.stdout
-            process.stderr
-          ]
+        exec cmd, { stdio }
 
   return if pkg then curried pkg else curried
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -34,13 +34,15 @@ reinstall = (options = {}, pkg) ->
     mktmp 'npm-git-'
       .then (path) ->
         tmp = path
+        cmd = "git clone #{url} #{tmp}"
         if verbose then console.log "Cloning '#{url}' into #{tmp}"
-        NodeGit.Clone url, tmp,
-          checkoutBranch: revision
-          fetchOpts     :
-            callbacks     :
-              certificateCheck: -> 1 # FIX for OSX (it rhymes :)
-              credentials     : (url, user) -> NodeGit.Cred.sshKeyFromAgent user
+
+        exec cmd,
+          stdio : [
+            'pipe'
+            if silent then 'pipe' else process.stdout
+            process.stderr
+          ]
 
       .then ->
         cmd = 'npm install'

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -30,6 +30,7 @@ reinstall = (options = {}, pkg) ->
 
   curried = ({ url, revision }) ->
     do temp.track
+
     tmp = null
     stdio = [
       'pipe'

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -28,7 +28,7 @@ reinstall = (options = {}, pkg) ->
     verbose
   } = options
 
-  curried = ({url, revision}) ->
+  curried = ({ url, revision }) ->
     do temp.track
     tmp = null
     stdio = [

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -43,6 +43,18 @@ reinstall = (options = {}, pkg) ->
             if silent then 'pipe' else process.stdout
             process.stderr
           ]
+      .then ->
+        cmd = "git checkout #{revision}"
+
+        if verbose then console.log "Checking out #{revision}"
+
+        exec cmd,
+          cwd   : tmp
+          stdio : [
+            'pipe'
+            if silent then 'pipe' else process.stdout
+            process.stderr
+          ]
 
       .then ->
         cmd = 'npm install'


### PR DESCRIPTION
Use standard git binary instead.

This introduces an external dependency on `git` command. It's seems to be shortest path to fix long standing issues #5 and #7.

**How to test**

For now manual tests are required. This new code is not yet released to NPM so in order to test in your project, do:

``` sh
git clone https://github.com/lzrski/npm-git-install.git
cd npm-git-install
git checkout drop-node-git
npm link
```

then in a directory of your project with git dependencies:

``` sh
npm link npm-git-install
npm-git install
```

> **Important:** that the CLI command is now `npm-git install` (there is a space between `npm-git` and `install`, where a dash `-` used to be). You may have to update `scripts` section in  your `package.json`.

Change of a CLI command was done in preparation of new subcommand: `shrinkwrap`. See discussion here: lambdatastic/npm-git-install#3

Big thanks to @lambdatastic, @racerpeter and @jrolfs for setting me on the right path.
