### PR TITLE
Install and save packages given on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,31 @@ In your `pacakge.json` add:
 }
 ```
 
-Obviously replace `*-package-name` and git URLs with values relevant to your project. URLs has to be in canonical form (i.e. one that you would provide to `git clone` on command line) - no fancy NPM shortcuts like "user/repo" or "bitbucket:user/repo". If you want this, I'm open for PR.
+Obviously replace `*-package-name` and git URLs with values relevant to your project. URLs has to be in canonical form (i.e. one that you would provide to `git clone` on command line) - no fancy NPM shortcuts like ~~`user/repo`~~ or ~~`bitbucket:user/repo`~~. If you want this, we are open for a PRs.
 
 Then install your dependencies as usual:
 
 ```sh
 npm install
 ```
+
+If you want to lock versions of git dependencies, use:
+
+```sh
+./node_modules/.bin/npm-git install --save
+```
+
+This will reinstall all git dependencies, but also write last matching commit's sha to `package.json`, effectively locking the versions.
+
+You can also add a dependency and lock it's sha in one go:
+
+```sh
+./node_modules/.bin/npm-git install --save me@my.git.server:me/my-awesome-thing.git
+```
+
+This is probably the safest option, as it guarantees the same revision to be installed every time.
+
+Now it should be easy to deploy, as long as the git executable is available in the environment.
 
 Why
 ---
@@ -79,6 +97,16 @@ You may want to do this if you find it offensive to put non-standard section in 
 
 Also try `--help` for more options.
 
+Just like with plain NPM, on the command line you can specify a space separated list of packages to be installed:
+
+```sh
+npm-git install https://github.com/someone/awesome.git me@git.server.com/me/is-also-awesome.git#experimantal-branch
+```
+
+After hash you can specify a branch name, tag or a specific commit's sha. By default `master` branch is used.
+
+With `--save` option it will write the sha of tha HEAD (i.e. last matching commit) to the package.json, effectively locking the version of the dependency.
+
 ### API
 
 You can also use it programmatically. Just require `npm-git-install`. It exposes four methods:
@@ -95,7 +123,7 @@ You can also use it programmatically. Just require `npm-git-install`. It exposes
 
     Options are the same as for `reinstall`.
 
-    Returns a `Promise`.
+    Returns a `Promise` that resolves to `report`, i.e. an array of `metadata` objects that you can pass to `save`. See below.
 
   * `reinstall (options, package)`
 
@@ -114,11 +142,25 @@ You can also use it programmatically. Just require `npm-git-install`. It exposes
     * `silent`: Suppress child processes standard output. Boolean. Default is `false`.
     * `verbose`: Print debug messages. Boolean. Default is `false`.
 
-    Returns a `Promise`.
+    Returns a `Promise` that will resolve to a `metadata` object:
+
+    ```coffee-script
+    {
+      name: "my-awesome-thing"
+      sha: "ef88c40"
+      url: "me@git.server.com/me/my-awesome-thing.git"
+    }
+    ```
 
     You probably don't want to use it directly. Just call `reinstall_all` with relevant options.
 
-If you are a [Gulp][] user, then it should be easy enough to integrate it with your gulpfile.
+  * `save (file, report)`
+
+    Takes a path to a package.json and an array of `metadata` (e.g. a `report` promised by `reinstall_all`). Updates the contents of the package.json file according to the report.
+
+    Returns `undefined`.
+
+If you are a [Gulp][] user, then it should be easy enough to integrate it with your gulpfile. See [./src/cli.coffee][] for example use of the API.
 
 ### Why not use `dependencies` and `devDependencies`
 


### PR DESCRIPTION
Now it is possible to call it like that:

``` sh
npm-git install --save \
  git@github.com:sample-package-1.git \
  https://github.com/sample-package-2.git#tag-or-branch-or-sha
```

This will install the packages, determine a `sha` of last commit that matches given revision (`master` by default) and save this to `package.json`'s `gitDependencies` section.

Next time one calls

``` sh
npm-git install
```

the same revisions of the packages will be installed.

This way one can have predictable deplpyments, even if new commits are added to the repo after initial installation. This is an alternative to #10.
## TODO
- [ ] update ReadMe
